### PR TITLE
Adding Driverreport container

### DIFF
--- a/lstchain/io/lstcontainers.py
+++ b/lstchain/io/lstcontainers.py
@@ -192,4 +192,5 @@ class drivereport(Container):
       El_avg = Field(-1,"Elevation")
       El_min = Field(-1,"Elevation min")
       El_max = Field(-1,"Elevation max")
-      El_rms = Field(-1,"Elevation RMS")    
+      El_rms = Field(-1,"Elevation RMS")
+      


### PR DESCRIPTION
This PR address the issue of adding a drive report container following the structure of the drive report.  This will be followed by a script which will use the container class to add a container (or group) to the DL1 data. I'll put another script where I show how the drive report appears in the DL1 h5 file